### PR TITLE
feat: 3.0.18 新增 qqGuildv2 指名适配

### DIFF
--- a/OlivaDiceJoy/app.json
+++ b/OlivaDiceJoy/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceJoy",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的娱乐模块，提供了一些无关紧要的娱乐功能，它们或许是与跑团关系不大、或许只是一些历史原因遗留下来的传统，总之，这些在野蛮生长时期被或是由于开发者无知、或是作为恶性竞争手段、或是用户呼声较大但对于跑团而言意义不明的，被添加进来的小功能，都会被放入这个模块。",
-    "version" : "3.0.17",
-    "svn" : 25,
+    "version" : "3.0.18",
+    "svn" : 26,
     "compatible_svn" : 190,
     "priority" : 20010,
     "support" : [

--- a/OlivaDiceJoy/data.py
+++ b/OlivaDiceJoy/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceJoy_ver = '3.0.17'
-OlivaDiceJoy_svn = 25
+OlivaDiceJoy_ver = '3.0.18'
+OlivaDiceJoy_svn = 26
 OlivaDiceJoy_ver_short = '%s(%s)' % (str(OlivaDiceJoy_ver), str(OlivaDiceJoy_svn))
 
 listPlugin = []

--- a/OlivaDiceJoy/msgReply.py
+++ b/OlivaDiceJoy/msgReply.py
@@ -243,6 +243,10 @@ def unity_reply(plugin_event, Proc):
         if plugin_event.data.extend['sub_self_id'] is not None:
             tmp_at_str_sub = OlivOS.messageAPI.PARA.at(plugin_event.data.extend['sub_self_id']).CQ()  # NOQA: F841
             tmp_id_str_sub = str(plugin_event.data.extend['sub_self_id'])
+    tmp_id_str_sub_open = None
+    if 'sub_self_open_id' in plugin_event.data.extend:
+        if plugin_event.data.extend['sub_self_open_id'] is not None:
+            tmp_id_str_sub_open = str(plugin_event.data.extend['sub_self_open_id'])
     tmp_command_str_1 = '.'  # NOQA: F841
     tmp_command_str_2 = '。'  # NOQA: F841
     tmp_command_str_3 = '/'  # NOQA: F841
@@ -277,6 +281,8 @@ def unity_reply(plugin_event, Proc):
         if tmp_id_str in tmp_at_list:
             flag_force_reply = True
         if tmp_id_str_sub in tmp_at_list:
+            flag_force_reply = True
+        if tmp_id_str_sub_open in tmp_at_list:
             flag_force_reply = True
         if 'all' in tmp_at_list:
             flag_force_reply = True


### PR DESCRIPTION
## Summary by Sourcery

Update entertainment module version and extend mention handling for QQ Guild v2 events.

New Features:
- Support mention-based force replies using sub_self_open_id for QQ Guild v2 events.

Enhancements:
- Extend reply force-detection logic to consider additional sub user identifiers in incoming events.

Build:
- Bump OlivaDiceJoy module version to 3.0.18 and increment svn to 26.